### PR TITLE
correct concatenation in joining Don't example

### DIFF
--- a/src/chapters/style/joining.typ
+++ b/src/chapters/style/joining.typ
@@ -15,7 +15,7 @@ Prefer statement joining over manual joining, this keeps code and markup similar
   // this is harder to read and edit
   #let res
   #for x in ("a", "b", "c") {
-    res + [- #x]
+    res += [- #x]
   }
   #res
   ```


### PR DESCRIPTION
The "Don't" example for content joining did not accumulate content in the `res` variable due to a missing assignment operator.