### PR TITLE
Switch `typ` raw lang annotation to `typst`

### DIFF
--- a/src/chapters/api/flexibility.typ
+++ b/src/chapters/api/flexibility.typ
@@ -9,7 +9,7 @@ Good APIs must be flexible enough to allow users to use them in situations a dev
 Starting with Typst 0.11, the #link("https://typst.app/docs/reference/context/")[context] feature allows certain functions to access information about the current location inside the document. The documentation gives the following example:
 
 #example(
-  ```typ
+  ```typst
   #let value = context text.lang
   #value
   --
@@ -22,7 +22,7 @@ Starting with Typst 0.11, the #link("https://typst.app/docs/reference/context/")
 The same `value` is rendered three times, but with different results. This is of course a powerful tool for library authors! However, there is an important restriction that `context` needs to impose to be able to do that: `context` values are opaque content; the above does not result in a string such as `"en"`, it just renders that way:
 
 #example(
-  ```typ
+  ```typst
   #let value = context text.lang
   Rendered: #value
 

--- a/src/chapters/style/delimiters.typ
+++ b/src/chapters/style/delimiters.typ
@@ -5,7 +5,7 @@
 Opening delimiters to unfinished statements like `(...)`, `[...]`, etc. are placed on the same line as their preceding element, e.g. for loops, declarations, etc.
 This is actually enforced by the compiler in most cases, as it uses line breaks to terminate most statements.
 #do-dont[
-  ```typ
+  ```typst
   // if it fits on one line avoid linebreaks
   #let var = if { ... }
 
@@ -22,7 +22,7 @@ This is actually enforced by the compiler in most cases, as it uses line breaks 
   }
   ```
 ][
-  ```typ
+  ```typst
   // this doesn't parse
   #let var =
   {

--- a/src/chapters/style/indentation.typ
+++ b/src/chapters/style/indentation.typ
@@ -6,14 +6,14 @@ Indentation is always 2 spaces per level, tabs can be used to increase accessibi
 For 2 spaces this means that for most syntactic elements, the indentation of nested items or continuations lines up with the start of the first line.
 This keeps nested code narrow, allowing side-by-side editing and preview for most users.
 #do-dont[
-  ```typ
+  ```typst
   // consistent easy to follow indentation
   - top level
     - nested
       continuation
   ```
 ][
-  ```typ
+  ```typst
   // inconsistent and too deep indentation
   - top level
       - nested

--- a/src/chapters/style/joining.typ
+++ b/src/chapters/style/joining.typ
@@ -4,14 +4,14 @@
 = Joining
 Prefer statement joining over manual joining, this keeps code and markup similar in structure to the end document.
 #do-dont[
-  ```typ
+  ```typst
   // in a document this clearly communicates intent
   #for x in ("a", "b", "c") [
     - #x
   ]
   ```
 ][
-  ```typ
+  ```typst
   // this is harder to read and edit
   #let res
   #for x in ("a", "b", "c") {

--- a/src/chapters/style/modes.typ
+++ b/src/chapters/style/modes.typ
@@ -4,7 +4,7 @@
 = Mode Switching
 Prefer staying in the primary mode of your current context, this avoids unnecessarily frequent use of `#` and unintended leading and trailing whitespace in #mode.mark.
 #do-dont[
-  ```typ
+  ```typst
   // we switched into code mode once and stay in it
   #figure(caption: [...],
     stack(dir: ltr,
@@ -14,7 +14,7 @@ Prefer staying in the primary mode of your current context, this avoids unnecess
   )
   ```
 ][
-  ```typ
+  ```typst
   // we switch back and forth, making writing and reading harder
   #figure(caption: [...])[
     #stack(dir: ltr)[

--- a/src/chapters/style/trailing.typ
+++ b/src/chapters/style/trailing.typ
@@ -6,12 +6,12 @@ Prefer trailing content argument calling style `#func(...)[...]` only for short 
 Trailing content arguments are harder to visually separate for complex or large amounts of arguments such as tables with multiple rows and make refactoring more noisy in diffs.
 
 #do-dont[
-  ```typ
+  ```typst
   #link("https://github.com")[github.com]
   #custom[a][b]
   ```
 ][
-  ```typ
+  ```typst
   // most tables
   #table[a][b][c]
   ```


### PR DESCRIPTION
This mainly helps with the lack of support for some editors, which may expect `typst` instead of `typ`.