### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # API & Style Guidelines
 This repository contains a document which outlines guidelines for developers across the Typst ecosystem to help them create packages and templates with good APIs and consistent styling.
-The guidlines are not hard rules, nor are they prefect, contributions and discussions to improve them are welcome.
+The guidelines are not hard rules, nor are they prefect, contributions and discussions to improve them are welcome.
 
 ## State
 This document is currently a draft and sections may change as it and the ecosystem evolves.
 
 ## Contributing
 If you wish to fix grammatical errors or improve the layout or appearance of the document feel free to open a PR directly.
-If you wish to propose a change to the guidlines itself, please open an issue to discuss the changes with the community.
+If you wish to propose a change to the guidelines itself, please open an issue to discuss the changes with the community.
 
 To preview, watch and build the document locally, see the [Justfile], you can use it anywhere by installing [just] and a sh-compatible shell.
 Alternatively, you can run the recipes manually by setting the required environment variables and arguments yourself.

--- a/src/chapters/api/flexibility.typ
+++ b/src/chapters/api/flexibility.typ
@@ -58,6 +58,6 @@ This means that returning a context expression limits what can be done with a fu
   ```
 ]
 
-The first variant of the `fancy-get-language` function allows the caller to do something with the returned language code (which, with this simplistic function is _necessary_ to domething useful); the latter one can only be rendered.
+The first variant of the `fancy-get-language` function allows the caller to do something with the returned language code (which, with this simplistic function is _necessary_ to do something useful); the latter one can only be rendered.
 
 There are of course exceptions to the rule: requiring using `context` is _a bit_ more complicated to call for users, so if there is no benefit (e.g. the function returns complex content where inspecting it doesn't make sense anyway) it may be more useful to just return opaque content so that the user does not need to think about context.

--- a/src/chapters/api/interoperability.typ
+++ b/src/chapters/api/interoperability.typ
@@ -11,7 +11,7 @@ When designing the API of your package, the following two questions should be co
 
 The choice to make an item private or part of a function's behavior hardcoded can negatively impact it's interoperability, but the opposite can lead to bloated and intimidating APIs.
 Depending on the target audience of your package you may chose one over the other.
-Developers may require APIs with more configurabe parameters while end users may just want a simple to use API that doesn't get in their way.
+Developers may require APIs with more configurable parameters while end users may just want a simple to use API that doesn't get in their way.
 
 == Visibility
 In order to provide other package authors with the ability to write extensions to your package they must usually be able to access certain internals of your package.
@@ -21,12 +21,12 @@ Or they can be exposed fully documented and stable but marked as internal or adv
 How and if they are exposed depends on your package's use cases and target audience.
 
 #wbox[
-  At the time of writing this Typst 0.11.1 doesn't support controlling the visiblity of items directly.
+  At the time of writing this Typst 0.11.1 doesn't support controlling the visibility of items directly.
 ]
 
 To mark an item private, consider simply prefixing it with an underscore like `_internal-func`.
-While it is not technically unreachable for a user, it is declared as discuraged to use and generally considered unstable, i.e. not part of the stability guarantees of your API.
-To truly make an item pivate it must be declared in a scope deeper than the top level of a module, such as inside a function or block expression without being returned from such a scope.
+While it is not technically unreachable for a user, it is declared as discouraged to use and generally considered unstable, i.e. not part of the stability guarantees of your API.
+To truly make an item private it must be declared in a scope deeper than the top level of a module, such as inside a function or block expression without being returned from such a scope.
 
 ```typst
 // public and stable
@@ -39,7 +39,7 @@ To truly make an item pivate it must be declared in a scope deeper than the top 
   // unreachable to anyone outside this module
   let truly-internal() = { ... }
 
-  // public and stable by virture of its "re-export"
+  // public and stable by virtue of its "re-export"
   let func() = { ... }
 
   func
@@ -68,11 +68,11 @@ For example, given a function which queries for and styles elements before a cer
   ```
 ]
 
-An example of both exposed internals and configrable behavior allowing interoperability is the #mty.package[Fletcher] package, which builds on #mty.package[Cetz].
+An example of both exposed internals and configurable behavior allowing interoperability is the #mty.package[Fletcher] package, which builds on #mty.package[CeTZ].
 #mty.package[Fletcher] exposes a simplified API to draw diagrams of all kinds involving arrows.
-In order to allow users to draw anything the package itself may not natively support, #mty.package[Fletcher] allows accessing all resolved coordinates and items before they are passed to #mty.package[Cetz] for drawing.
+In order to allow users to draw anything the package itself may not natively support, #mty.package[Fletcher] allows accessing all resolved coordinates and items before they are passed to #mty.package[CeTZ] for drawing.
 
-See @sec:api:flex for more guidelines on flexibilty.
+See @sec:api:flex for more guidelines on flexibility.
 
 ```typst
 #fletcher.diagram(
@@ -100,7 +100,7 @@ A package may decide if it omits this or maintains a representation which is con
 The package unique key is unique within the package and can be freely chosen.
 
 Similarly to the keys of counters and states, labels also share a global namespace, once put into the document.
-Consider a similar approach for these labels, as well as using names invalid for `@ref` syntax, this ensures that LSPs do not pollute label completions with values which are not meant to be refered to by a user.
+Consider a similar approach for these labels, as well as using names invalid for `@ref` syntax, this ensures that LSPs do not pollute label completions with values which are not meant to be referred to by a user.
 An example of this is including whitespace or other non-identifier characters in the key.
 A key like `__ pkg:0.1.0:label:backref-anchor` (notice the space after the double underscores) cannot be used in `@ref` syntax and will therefore not be suggested as a completion.
 

--- a/src/chapters/api/simplicity.typ
+++ b/src/chapters/api/simplicity.typ
@@ -5,9 +5,9 @@
 Good APIs should be simple, easy to use and aware of their primary use case. Flexibility as discussed in @sec:api:flex should not interfere with the usability of an API.
 
 == Higher Order Templates
-A common pattern for Typst templates is to provide a single top level function, which a user imports and applys with a show-all rule, i.e. `show: func`.
+A common pattern for Typst templates is to provide a single top level function, which a user imports and applies with a show-all rule, i.e. `show: func`.
 This makes for a simple API in the case of no arguments, but requires extra thought when arguments have to be applied.
-This idiom also comes with additional boilerplate in almost any template, templates are almost never appled without any arguments.
+This idiom also comes with additional boilerplate in almost any template, templates are almost never applied without any arguments.
 By using functions as values, a template author can provide a simpler API for the most common use case of applying this function as a template.
 
 Consider returning a function which is applied in the show-all rule from your template function, instead of taking the content itself.

--- a/src/chapters/style/expression-blocks.typ
+++ b/src/chapters/style/expression-blocks.typ
@@ -18,7 +18,7 @@ Prefer implicit block expression values over explicit `return`.
   ```
 ]
 
-Prefer assignment of expression block expressions over mutation of existing delcarations.
+Prefer assignment of expression block expressions over mutation of existing declarations.
 #do-dont[
   ```typc
   let x = if var { 0 } else { 1 }
@@ -51,7 +51,7 @@ Prefer implicit block expression values over explicit `return`.
   ```
 ]
 
-Prefer assignment of expression block expressions over mutation of existing delcarations.
+Prefer assignment of expression block expressions over mutation of existing declarations.
 #do-dont[
   ```typc
   let x = if var { 0 } else { 1 }


### PR DESCRIPTION
Besides, I can’t `just build` with typst v0.13.0, because the version of [mantys](https://typst.app/universe/package/mantys) is too old.
