### PR TITLE
chore: Corrected license in typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -2,7 +2,7 @@
 [package]
 name = "api-style-guidelines"
 version = "0.1.0"
-license = "MIT"
+license = "CC-BY-SA-4.0"
 authors = [
   "tinger <me@tinger.dev>",
 ]


### PR DESCRIPTION
The canonical license of was already in the `LICENSE` file.